### PR TITLE
Add initial implementation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2021, Hyvä Themes B.V.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Compatible with Magento 2.3.4 and higher.
 It adds:
  - `\Hyva\GraphqlViewModel\ViewModel\GraphqlViewModel`, to be accessed via the view model registry.
  - `\Hyva\GraphqlViewModel\Model\GraphqlQueryEditor` which can be used to add fields and arguments to GraphQL queries.
- - The event `hyva_graphql_query_before_render`
-   Event observers receive the parsed query that can be manipulated with the `GraphqlQueryEditor`
+ - The event `hyva_graphql_query_before_render_` + query identifier
+   Event observers receive the query string and can manipulate it with the `GraphqlQueryEditor`
 
 ## Usage
 
 In a `.phtml` template, to make a query customizable, wrap it in the `GraphqlViewModel::query()` method:
 ```php
-$query = $gqlViewModel->query("product_list_query", "
+<?= $gqlViewModel->query("product_list_query", "
 products(filter: {} pageSize: 20) {
   items {
     {$type}_products {
@@ -35,16 +35,14 @@ products(filter: {} pageSize: 20) {
         }
     }
   }
-}");
-<?= $query ?>
+}")
+?>
 ```
-The first argument is used to identify a query in event observers.
+The first argument is the event name suffix, the second argument is the query or mutation.
 
 To manipulate a query in an event observer, the GraphqlQueryEditor can be used:
 ```php
-if ($event->getData('name') !== 'product_list_query') {
-    return;
-}
+
 $query = $event->getData('gql_container')->getData('query');
 
 $gqlEditor = new GraphqlQueryEditor(); // or use dependency injection

--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@ Compatible with Magento 2.3.4 and higher.
 
 It adds:
  - `\Hyva\GraphqlViewModel\ViewModel\GraphqlViewModel`, to be accessed via the view model registry.
-   The method `GraphqlViewModel::toAst` and `GraphqlViewModel::query` can be used as plugin targets.
-- `\Hyva\GraphqlViewModel\Model\GraphqlQueryEditor` which can be used to add fields and arguments to GraphQL queries.
+ - `\Hyva\GraphqlViewModel\Model\GraphqlQueryEditor` which can be used to add fields and arguments to GraphQL queries.
  - The event `hyva_graphql_query_before_render`
    Event observers receive the parsed query that can be manipulated with the `GraphqlQueryEditor`
 
 ## Usage
 
 In a `.phtml` template, to make a query customizable, wrap it in the `GraphqlViewModel::query()` method:
-```
-$query = $gqlViewModel->query("product_query", "
+```php
+$query = $gqlViewModel->query("product_list_query", "
 products(filter: {} pageSize: 20) {
   items {
     {$type}_products {
@@ -39,19 +38,39 @@ products(filter: {} pageSize: 20) {
 }");
 <?= $query ?>
 ```
-The first argument is used to identify a query in event observers or plugins.
+The first argument is used to identify a query in event observers.
+
+To manipulate a query in an event observer, the GraphqlQueryEditor can be used:
+```php
+if ($event->getData('name') !== 'product_list_query') {
+    return;
+}
+
+$query = $event->getData('query');
+$gqlEditor = new GraphqlQueryEditor(); // or use dependency injection
+
+// add a single field to a result object
+$gqlEditor->setFieldIn($query, ['products', 'items', 'small_image'], 'url_webp');
+
+// add multiple fields to a result object
+$gqlEditor->setFieldIn($query, ['products', 'items', 'image'], 'url label url_webp');
+
+// add a query argument
+$gqlEditor->setArgumentIn($query, ['products', 'filter', 'name'], 'match', 'Tank');
+$gqlEditor->setArgumentIn($query, ['products'], 'pageSize', 2);
+```
 
 ## Installation
   
 1. Install via composer
-    ```
-    composer config repositories.hyva-themes/magento2-graphql-view-model git git@github.com:hyva-themes/magento2-graphql-view-model.git
-    composer require hyva-themes/magento2-graphql-view-model
-    ```
+```
+composer config repositories.hyva-themes/magento2-graphql-view-model git git@github.com:hyva-themes/magento2-graphql-view-model.git
+composer require hyva-themes/magento2-graphql-view-model
+```
 2. Enable module
-    ```
-    bin/magento setup:upgrade
-    ```
+```
+bin/magento module:enable Hyva_GraphqlViewModel
+```
 ## Configuration
   
 No configuration needed.

--- a/README.md
+++ b/README.md
@@ -45,19 +45,22 @@ To manipulate a query in an event observer, the GraphqlQueryEditor can be used:
 if ($event->getData('name') !== 'product_list_query') {
     return;
 }
+$query = $event->getData('gql_container')->getData('query');
 
-$query = $event->getData('query');
 $gqlEditor = new GraphqlQueryEditor(); // or use dependency injection
 
 // add a single field to a result object
-$gqlEditor->setFieldIn($query, ['products', 'items', 'small_image'], 'url_webp');
+$query = $gqlEditor->setFieldIn($query, ['products', 'items', 'small_image'], 'url_webp');
 
 // add multiple fields to a result object
-$gqlEditor->setFieldIn($query, ['products', 'items', 'image'], 'url label url_webp');
+$query = $gqlEditor->setFieldIn($query, ['products', 'items', 'image'], 'url label url_webp');
 
 // add a query argument
-$gqlEditor->setArgumentIn($query, ['products', 'filter', 'name'], 'match', 'Tank');
-$gqlEditor->setArgumentIn($query, ['products'], 'pageSize', 2);
+$query = $gqlEditor->setArgumentIn($query, ['products', 'filter', 'name'], 'match', 'Tank');
+$query = $gqlEditor->setArgumentIn($query, ['products'], 'pageSize', 2);
+
+// set updated query back on container
+$event->getData('gql_container')->setData('query', $query);
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Hyvä Themes - GraphQL ViewModel module
+
+**Note: This module is currently experimental and might be removed or changed without notice**
+
+[![Hyvä Themes](https://repository-images.githubusercontent.com/300568807/f00eb480-55b1-11eb-93d2-074c3edd2d07)](https://hyva.io/)
+
+## hyva-themes/magento2-graphql-view-model
+
+![Supported Magento Versions][ico-compatibility]
+
+This module adds a GraphQL ViewModel to allow GraphQL queries and mutations to be customized before they are rendered in the output.
+
+Compatible with Magento 2.3.4 and higher.
+
+## What does it do?
+
+It adds:
+ - `\Hyva\GraphqlViewModel\ViewModel\GraphqlViewModel`, to be accessed via the view model registry.
+   The method `GraphqlViewModel::toAst` and `GraphqlViewModel::query` can be used as plugin targets.
+- `\Hyva\GraphqlViewModel\Model\GraphqlQueryEditor` which can be used to add fields and arguments to GraphQL queries.
+ - The event `hyva_graphql_query_before_render`
+   Event observers receive the parsed query that can be manipulated with the `GraphqlQueryEditor`
+
+## Usage
+
+In a `.phtml` template, to make a query customizable, wrap it in the `GraphqlViewModel::query()` method:
+```
+$query = $gqlViewModel->query("product_query", "
+products(filter: {} pageSize: 20) {
+  items {
+    {$type}_products {
+        sku
+        id
+        small_image {
+          url
+        }
+    }
+  }
+}");
+<?= $query ?>
+```
+The first argument is used to identify a query in event observers or plugins.
+
+## Installation
+  
+1. Install via composer
+    ```
+    composer config repositories.hyva-themes/magento2-graphql-view-model git git@github.com:hyva-themes/magento2-graphql-view-model.git
+    composer require hyva-themes/magento2-graphql-view-model
+    ```
+2. Enable module
+    ```
+    bin/magento setup:upgrade
+    ```
+## Configuration
+  
+No configuration needed.
+
+## License
+
+The MIT License (MIT). Please see [License File](LICENSE.txt) for more information.
+
+[ico-compatibility]: https://img.shields.io/badge/magento-%202.3%20|%202.4-brightgreen.svg?logo=magento&longCache=true&style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "hyva-themes/magento2-graphql-view-model",
+    "description": "Provide ability to customize GraphQL queries and mutations for Hyvä themes.",
+    "require": {
+        "php": "^7.3.0"
+    },
+    "type": "magento2-module",
+    "license": [
+        "BSD-3-Clause"
+    ],
+    "autoload": {
+        "files": [
+            "src/registration.php"
+        ],
+        "psr-4": {
+            "Hyva\\GraphqlViewModel\\": "src/"
+        }
+    }
+}

--- a/src/Model/GraphqlQueryEditor.php
+++ b/src/Model/GraphqlQueryEditor.php
@@ -48,15 +48,16 @@ class GraphqlQueryEditor
      * Add GraphQL query or mutation field at given path.
      *
      * Example:
-     * $editor->setFieldIn($ast, ['products', 'items', 'small_image'], 'url_webp');
+     * $query = $editor->setFieldIn($query, ['products', 'items', 'small_image'], 'url_webp');
      *
-     * @param DocumentNode $ast
+     * @param string $query
      * @param array $path
      * @param string $field
-     * @return DocumentNode
+     * @return string
      */
-    public function setFieldIn(DocumentNode $ast, array $path, string $field): DocumentNode
+    public function setFieldIn(string $query, array $path, string $field): string
     {
+        $ast = \GraphQL\Language\Parser::parse(new \GraphQL\Language\Source($query));
         $operation = $this->getFirstOperationNode($ast);
         $target    = $this->getFieldSelection($operation, $path);
         foreach (preg_split('/\s+/', $field) as $new) {
@@ -65,24 +66,25 @@ class GraphqlQueryEditor
             }
         }
 
-        return $ast;
+        return \GraphQL\Language\Printer::doPrint($ast);
     }
 
     /**
      * Add or set argument to value at given path for GraphQL query or mutation.
      *
      * Examples:
-     * $editor->setArgumentIn($ast, ['products', 'filter', 'name'], 'match', 'Tank');
-     * $editor->setArgumentIn($ast, ['products'], 'pageSize', 2);
+     * $query = $editor->setArgumentIn($query, ['products', 'filter', 'name'], 'match', 'Tank');
+     * $query = $editor->setArgumentIn($query, ['products'], 'pageSize', 2);
      *
-     * @param DocumentNode $ast
+     * @param string $query
      * @param array $path
      * @param string $key
      * @param string|int|float|bool|null $value
-     * @return DocumentNode
+     * @return string
      */
-    public function setArgumentIn(DocumentNode $ast, array $path, string $key, $value): DocumentNode
+    public function setArgumentIn(string $query, array $path, string $key, $value): string
     {
+        $ast = \GraphQL\Language\Parser::parse(new \GraphQL\Language\Source($query));
         $operationField = array_shift($path); // e.g. products
         $argumentName   = array_shift($path); // e.g. filter
         $operationField = $this->getFieldSelection($this->getFirstOperationNode($ast), [$operationField]);
@@ -90,7 +92,7 @@ class GraphqlQueryEditor
         $target         = $this->getArgumentField($argument, $path);
         $this->setArgumentFieldIn($target, $key, $value);
 
-        return $ast;
+        return \GraphQL\Language\Printer::doPrint($ast);
     }
 
     private function getArgument(FieldNode $target, string $name): ArgumentNode

--- a/src/Model/GraphqlQueryEditor.php
+++ b/src/Model/GraphqlQueryEditor.php
@@ -1,0 +1,274 @@
+<?php declare(strict_types=1);
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes. All rights reserved.
+ * See LICENSE.md for license details
+ */
+
+namespace Hyva\GraphqlViewModel\Model;
+
+use GraphQL\Language\AST\ArgumentNode;
+use GraphQL\Language\AST\BooleanValueNode;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\AST\FloatValueNode;
+use GraphQL\Language\AST\IntValueNode;
+use GraphQL\Language\AST\NameNode;
+use GraphQL\Language\AST\Node;
+use GraphQL\Language\AST\NodeKind;
+use GraphQL\Language\AST\NodeList;
+use GraphQL\Language\AST\NullValueNode;
+use GraphQL\Language\AST\ObjectFieldNode;
+use GraphQL\Language\AST\ObjectValueNode;
+use GraphQL\Language\AST\OperationDefinitionNode;
+use GraphQL\Language\AST\SelectionSetNode;
+use GraphQL\Language\AST\StringValueNode;
+use function array_slice as slice;
+use function array_keys as keys;
+
+class GraphqlQueryEditor
+{
+    /**
+     * Returns the fist operations node since Magento only supports single operation GraphQL requests.
+     *
+     * @param DocumentNode $ast
+     * @return OperationDefinitionNode|null
+     */
+    private function getFirstOperationNode(DocumentNode $ast): ?OperationDefinitionNode
+    {
+        foreach ($ast->definitions as $definition) {
+            if ($definition->kind === NodeKind::OPERATION_DEFINITION) {
+                return $definition;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Add GraphQL query or mutation field at given path.
+     *
+     * Example:
+     * $object->setFieldIn($ast, ['products', 'items', 'small_image'], 'url_webp');
+     *
+     * @param DocumentNode $ast
+     * @param array $path
+     * @param string $field
+     * @return DocumentNode
+     */
+    public function setFieldIn(DocumentNode $ast, array $path, string $field): DocumentNode
+    {
+        $operation = $this->getFirstOperationNode($ast);
+        $target    = $this->getFieldSelection($operation, $path);
+        foreach (preg_split('/\s+/', $field) as $new) {
+            if (!$this->findFieldSelectionByName($target, $new)) {
+                $this->createFieldSelectionIn($target, $new);
+            }
+        }
+
+        return $ast;
+    }
+
+    /**
+     * Add or set argument to value at given path for GraphQL query or mutation.
+     *
+     * Examples:
+     * $sut->setArgumentIn($ast, ['products', 'filter', 'name'], 'match', 'Tank');
+     * $sut->setArgumentIn($ast, ['products'], 'pageSize', 2);
+     *
+     * @param DocumentNode $ast
+     * @param array $path
+     * @param string $key
+     * @param string|int|float|bool|null $value
+     * @return DocumentNode
+     */
+    public function setArgumentIn(DocumentNode $ast, array $path, string $key, $value): DocumentNode
+    {
+        $operationField = array_shift($path); // e.g. products
+        $argumentName   = array_shift($path); // e.g. filter
+        $operationField = $this->getFieldSelection($this->getFirstOperationNode($ast), [$operationField]);
+        $argument       = $argumentName ? $this->getArgument($operationField, $argumentName) : $operationField;
+        $target         = $this->getArgumentField($argument, $path);
+        $this->setArgumentFieldIn($target, $key, $value);
+
+        return $ast;
+    }
+
+    private function getArgument(FieldNode $target, string $name): ArgumentNode
+    {
+        return $this->findArgumentByName($target, $name) ?? $this->createArgument($target, $name);
+    }
+
+    private function findArgumentByName(FieldNode $target, string $name): ?ArgumentNode
+    {
+        foreach ($target->arguments as $argument) {
+            if ($argument->name->value === $name) {
+                return $argument;
+            }
+        }
+        return null;
+    }
+
+    private function createArgument(FieldNode $target, string $name): ArgumentNode
+    {
+        $argument = new ArgumentNode([
+            'name'  => new NameNode(['value' => $name]),
+            'value' => new ObjectValueNode(['fields' => new NodeList([])]),
+        ]);
+
+        $target->arguments[$this->nextIndex($target->arguments)] = $argument;
+        return $argument;
+    }
+
+    /**
+     * @param ObjectFieldNode|ArgumentNode $node
+     * @param string[] $path
+     * @return ObjectFieldNode|FieldNode
+     */
+    private function getArgumentField(Node $node, array $path): Node
+    {
+        if (empty($path)) {
+            return $node;
+        }
+        $field = $this->findObjectFieldByName($node, $path[0]) ?? $this->createObjectFieldIn($node, $path[0]);
+
+        return $this->getArgumentField($field, slice($path, 1));
+    }
+
+    /**
+     * @param FieldNode|OperationDefinitionNode $node
+     * @param string[] $path
+     * @return Node
+     */
+    private function getFieldSelection(Node $node, array $path): FieldNode
+    {
+        if (empty($path)) {
+            return $node;
+        }
+
+        $field = $this->findFieldSelectionByName($node, $path[0]) ?? $this->createFieldSelectionIn($node, $path[0]);
+
+        return $this->getFieldSelection($field, slice($path, 1));
+    }
+
+    /**
+     * @param ObjectFieldNode|ArgumentNode $node
+     * @param string $name
+     * @return ObjectFieldNode|null
+     */
+    private function findObjectFieldByName(Node $node, string $name): ?ObjectFieldNode
+    {
+        if (!isset($node->value->fields)) {
+            return null;
+        }
+        foreach ($node->value->fields as $field) {
+            if ($field->name && $field->name->value == $name) {
+                return $field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param FieldNode|OperationDefinitionNode $node
+     * @param string $name
+     * @return FieldNode|null
+     */
+    private function findFieldSelectionByName(Node $node, string $name): ?FieldNode
+    {
+        if (!is_object($node->selectionSet)) {
+            return null;
+        }
+        foreach ($node->selectionSet->selections as $field) {
+            if ($field->name && $field->name->value === $name) {
+                return $field;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param FieldNode|OperationDefinitionNode $node
+     * @param string $name
+     * @return FieldNode
+     */
+    private function createFieldSelectionIn(Node $node, string $name): FieldNode
+    {
+        $field = new FieldNode([
+            'name'         => new NameNode(['value' => $name]),
+            'arguments'    => new NodeList([]),
+            'directives'   => new NodeList([]),
+            'selectionSet' => new SelectionSetNode(['selections' => []]),
+        ]);
+
+        $node->selectionSet->selections[$this->nextIndex($node->selectionSet->selections)] = $field;
+
+        return $field;
+    }
+
+    /**
+     * @param ObjectFieldNode $node
+     * @param string $name
+     * @return ObjectFieldNode
+     */
+    private function createObjectFieldIn(Node $node, string $name): ObjectFieldNode
+    {
+        $field = new ObjectFieldNode([
+            'name'  => new NameNode(['value' => $name]),
+            'value' => new ObjectValueNode(['fields' => new NodeList([])]),
+        ]);
+
+        $node->value->fields[$this->nextIndex($node->value->fields)] = $field;
+
+        return $field;
+    }
+
+    /**
+     * @param ObjectFieldNode|FieldNode $target
+     * @param string $key
+     * @param string|int|bool|float|null $value
+     */
+    private function setArgumentFieldIn(Node $target, string $key, $value): void
+    {
+
+        /** @see \GraphQL\Language\AST\ValueNode */
+        $types = [
+            'string'  => StringValueNode::class,
+            'integer' => IntValueNode::class,
+            'double'  => FloatValueNode::class,
+            'NULL'    => NullValueNode::class,
+            'boolean' => BooleanValueNode::class,
+        ];
+        $type  = gettype($value);
+        if (!isset($types[$type])) {
+            throw new \RuntimeException('Unable to set GraphQL argument value type "%s"', $type);
+        }
+
+        $valueInstance = $this->getArgumentValueContainerFor($target, $key);
+        $valueInstance->value = new $types[$type](['value' => $value]);
+    }
+
+    private function getArgumentValueContainerFor(Node $target, string $name): Node
+    {
+        if ($target instanceof ObjectFieldNode) {
+            $valueInstance = $this->findObjectFieldByName($target, $name) ?? $this->createObjectFieldIn($target, $name);
+        } elseif ($target instanceof FieldNode) {
+            $valueInstance = $this->findArgumentByName($target, $name) ?? $this->createArgument($target, $name);
+        } else {
+            throw new \RuntimeException(sprintf('Unsupported target for argument value: "%s"', get_class($target)));
+        }
+
+        return $valueInstance;
+    }
+
+    /**
+     * @param array|\Iterator $array
+     * @return int
+     */
+    private function nextIndex($array): int
+    {
+        $keys = keys(is_array($array) ? $array : iterator_to_array($array));
+        return empty($keys)
+            ? 0
+            : max($keys) + 1;
+    }
+}

--- a/src/Model/GraphqlQueryEditor.php
+++ b/src/Model/GraphqlQueryEditor.php
@@ -157,10 +157,8 @@ class GraphqlQueryEditor
      */
     private function findObjectFieldByName(Node $node, string $name): ?ObjectFieldNode
     {
-        if (!isset($node->value->fields)) {
-            return null;
-        }
-        foreach ($node->value->fields as $field) {
+        $children = $node->value->fields ?? [];
+        foreach ($children as $field) {
             if ($field->name && $field->name->value == $name) {
                 return $field;
             }
@@ -175,10 +173,8 @@ class GraphqlQueryEditor
      */
     private function findFieldSelectionByName(Node $node, string $name): ?FieldNode
     {
-        if (!is_object($node->selectionSet)) {
-            return null;
-        }
-        foreach ($node->selectionSet->selections as $field) {
+        $children = is_object($node->selectionSet) ? $node->selectionSet->selections : [];
+        foreach ($children as $field) {
             if ($field->name && $field->name->value === $name) {
                 return $field;
             }

--- a/src/Model/GraphqlQueryEditor.php
+++ b/src/Model/GraphqlQueryEditor.php
@@ -48,7 +48,7 @@ class GraphqlQueryEditor
      * Add GraphQL query or mutation field at given path.
      *
      * Example:
-     * $object->setFieldIn($ast, ['products', 'items', 'small_image'], 'url_webp');
+     * $editor->setFieldIn($ast, ['products', 'items', 'small_image'], 'url_webp');
      *
      * @param DocumentNode $ast
      * @param array $path
@@ -72,8 +72,8 @@ class GraphqlQueryEditor
      * Add or set argument to value at given path for GraphQL query or mutation.
      *
      * Examples:
-     * $sut->setArgumentIn($ast, ['products', 'filter', 'name'], 'match', 'Tank');
-     * $sut->setArgumentIn($ast, ['products'], 'pageSize', 2);
+     * $editor->setArgumentIn($ast, ['products', 'filter', 'name'], 'match', 'Tank');
+     * $editor->setArgumentIn($ast, ['products'], 'pageSize', 2);
      *
      * @param DocumentNode $ast
      * @param array $path

--- a/src/ViewModel/GraphqlViewModel.php
+++ b/src/ViewModel/GraphqlViewModel.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes. All rights reserved.
+ * See LICENSE.md for license details
+ */
+
+namespace Hyva\GraphqlViewModel\ViewModel;
+
+use Magento\Framework\Event\ManagerInterface as EventManager;
+use Magento\Framework\View\Element\Block\ArgumentInterface;
+
+class GraphqlViewModel implements ArgumentInterface
+{
+    /**
+     * @var EventManager
+     */
+    private $eventManager;
+
+    public function __construct(EventManager $eventManager)
+    {
+        $this->eventManager = $eventManager;
+    }
+
+    public function query(string $name, string $query): string
+    {
+        return $this->toString($this->toAst($name, $query));
+    }
+
+    public function toAst(string $name, string $query): \GraphQL\Language\AST\DocumentNode
+    {
+        $source = new \GraphQL\Language\Source($query);
+        $ast    = \GraphQL\Language\Parser::parse($source);
+
+        $this->eventManager->dispatch('hyva_graphql_query_before_render', ['query' => $ast, 'name' => $name]);
+
+        return $ast;
+    }
+
+    private function toString(\GraphQL\Language\AST\DocumentNode $ast): string
+    {
+        return \GraphQL\Language\Printer::doPrint($ast);
+    }
+}

--- a/src/ViewModel/GraphqlViewModel.php
+++ b/src/ViewModel/GraphqlViewModel.php
@@ -27,7 +27,7 @@ class GraphqlViewModel implements ArgumentInterface
         return $this->toString($this->toAst($name, $query));
     }
 
-    public function toAst(string $name, string $query): \GraphQL\Language\AST\DocumentNode
+    private function toAst(string $name, string $query): \GraphQL\Language\AST\DocumentNode
     {
         $source = new \GraphQL\Language\Source($query);
         $ast    = \GraphQL\Language\Parser::parse($source);

--- a/src/ViewModel/GraphqlViewModel.php
+++ b/src/ViewModel/GraphqlViewModel.php
@@ -23,11 +23,27 @@ class GraphqlViewModel implements ArgumentInterface
         $this->eventManager = $eventManager;
     }
 
-    public function query(string $name, string $query): string
+    /**
+     * Dispatch event with query or mutation string to allow changing the query in event observers.
+     *
+     * The event name is 'hyva_graphql_query_before_render_' with the query identifier as a event suffix.
+     * To change the query, use the following code to fetch the query string.
+     *     $query = $observer->getData('gql_container')->getData('query')
+     *
+     * Then apply any required changes, and set it back on the event container:
+     *     $observer->getData('gql_container')->setData('query', $query)
+     *
+     * To modify the query the utility class \Hyva\GraphqlViewModel\Model\GraphqlQueryEditor might be useful.
+     *
+     * @param string $queryIdentifier
+     * @param string $query
+     * @return string
+     */
+    public function query(string $queryIdentifier, string $query): string
     {
         $container = new DataObject(['query' => $query]);
-        $params    = ['gql_container' => $container, 'name' => $name];
-        $this->eventManager->dispatch('hyva_graphql_query_before_render', $params);
+        $params    = ['gql_container' => $container];
+        $this->eventManager->dispatch('hyva_graphql_query_before_render_' . $queryIdentifier, $params);
 
         return $container->getData('query');
     }

--- a/src/ViewModel/GraphqlViewModel.php
+++ b/src/ViewModel/GraphqlViewModel.php
@@ -7,6 +7,7 @@
 
 namespace Hyva\GraphqlViewModel\ViewModel;
 
+use Magento\Framework\DataObject;
 use Magento\Framework\Event\ManagerInterface as EventManager;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 
@@ -24,21 +25,10 @@ class GraphqlViewModel implements ArgumentInterface
 
     public function query(string $name, string $query): string
     {
-        return $this->toString($this->toAst($name, $query));
-    }
+        $container = new DataObject(['query' => $query]);
+        $params    = ['gql_container' => $container, 'name' => $name];
+        $this->eventManager->dispatch('hyva_graphql_query_before_render', $params);
 
-    private function toAst(string $name, string $query): \GraphQL\Language\AST\DocumentNode
-    {
-        $source = new \GraphQL\Language\Source($query);
-        $ast    = \GraphQL\Language\Parser::parse($source);
-
-        $this->eventManager->dispatch('hyva_graphql_query_before_render', ['query' => $ast, 'name' => $name]);
-
-        return $ast;
-    }
-
-    private function toString(\GraphQL\Language\AST\DocumentNode $ast): string
-    {
-        return \GraphQL\Language\Printer::doPrint($ast);
+        return $container->getData('query');
     }
 }

--- a/src/etc/module.xml
+++ b/src/etc/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+ /**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes. All rights reserved.
+ * See LICENSE.md for license details
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Hyva_GraphqlViewModel"/>
+</config>

--- a/src/registration.php
+++ b/src/registration.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes. All rights reserved.
+ * See LICENSE.md for license details
+ */
+
+use \Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Hyva_GraphqlViewModel', __DIR__);

--- a/tests/unit/Model/GraphqlQueryEditorTest.php
+++ b/tests/unit/Model/GraphqlQueryEditorTest.php
@@ -7,7 +7,6 @@
 
 namespace Hyva\GraphqlViewModel\Model;
 
-use GraphQL\Language\Printer;
 use PHPUnit\Framework\TestCase;
 
 class GraphqlQueryEditorTest extends TestCase
@@ -47,21 +46,18 @@ class GraphqlQueryEditorTest extends TestCase
   }
 }
 ';
-
-        $ast = \GraphQL\Language\Parser::parse(new \GraphQL\Language\Source($query));
-
         $sut = new GraphqlQueryEditor();
 
         // new field in existing query object
-        $sut->setFieldIn($ast, ['products', 'items', 'small_image'], 'url_webp');
+        $query = $sut->setFieldIn($query, ['products', 'items', 'small_image'], 'url_webp');
 
         // multiple fields in new query object
-        $sut->setFieldIn($ast, ['products', 'items', 'image'], 'url label url_webp');
+        $query = $sut->setFieldIn($query, ['products', 'items', 'image'], 'url label url_webp');
 
         // existing field, idempotent
-        $sut->setFieldIn($ast, ['products'], 'total_count');
+        $query = $sut->setFieldIn($query, ['products'], 'total_count');
 
-        $this->assertSame($expected, Printer::doPrint($ast));
+        $this->assertSame($expected, $query);
     }
 
     public function testSetsGivenArgumentsOnQuery()
@@ -93,13 +89,12 @@ class GraphqlQueryEditorTest extends TestCase
   }
 }
 ';
-        $ast = \GraphQL\Language\Parser::parse(new \GraphQL\Language\Source($query));
-
         $sut = new GraphqlQueryEditor();
 
-        $sut->setArgumentIn($ast, ['products', 'filter', 'name'], 'match', 'Tank');
-        $sut->setArgumentIn($ast, ['products'], 'pageSize', 2);
+        $query = $sut->setArgumentIn($query, ['products', 'filter', 'name'], 'match', 'Tank');
 
-        $this->assertSame($expected, Printer::doPrint($ast));
+        $query = $sut->setArgumentIn($query, ['products'], 'pageSize', 2);
+
+        $this->assertSame($expected, $query);
     }
 }

--- a/tests/unit/Model/GraphqlQueryEditorTest.php
+++ b/tests/unit/Model/GraphqlQueryEditorTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes. All rights reserved.
+ * See LICENSE.md for license details
+ */
+
+namespace Hyva\GraphqlViewModel\Model;
+
+use GraphQL\Language\Printer;
+use PHPUnit\Framework\TestCase;
+
+class GraphqlQueryEditorTest extends TestCase
+{
+    public function testSetsGivenFieldsOnQuery(): void
+    {
+        $query = '{
+  products(filter: {name: {match: "Tank"}}) {
+    total_count
+    items {
+      name
+      small_image {
+        url
+        label
+      }
+    }
+  }
+}
+';
+
+        $expected = '{
+  products(filter: {name: {match: "Tank"}}) {
+    total_count
+    items {
+      name
+      small_image {
+        url
+        label
+        url_webp
+      }
+      image {
+        url
+        label
+        url_webp
+      }
+    }
+  }
+}
+';
+
+        $ast = \GraphQL\Language\Parser::parse(new \GraphQL\Language\Source($query));
+
+        $sut = new GraphqlQueryEditor();
+
+        // new field in existing query object
+        $sut->setFieldIn($ast, ['products', 'items', 'small_image'], 'url_webp');
+
+        // multiple fields in new query object
+        $sut->setFieldIn($ast, ['products', 'items', 'image'], 'url label url_webp');
+
+        // existing field, idempotent
+        $sut->setFieldIn($ast, ['products'], 'total_count');
+
+        $this->assertSame($expected, Printer::doPrint($ast));
+    }
+
+    public function testSetsGivenArgumentsOnQuery()
+    {
+        $query = '{
+  products {
+    total_count
+    items {
+      name
+      small_image {
+        url
+        label
+      }
+    }
+  }
+}
+';
+
+        $expected = '{
+  products(filter: {name: {match: "Tank"}}, pageSize: 2) {
+    total_count
+    items {
+      name
+      small_image {
+        url
+        label
+      }
+    }
+  }
+}
+';
+        $ast = \GraphQL\Language\Parser::parse(new \GraphQL\Language\Source($query));
+
+        $sut = new GraphqlQueryEditor();
+
+        $sut->setArgumentIn($ast, ['products', 'filter', 'name'], 'match', 'Tank');
+        $sut->setArgumentIn($ast, ['products'], 'pageSize', 2);
+
+        $this->assertSame($expected, Printer::doPrint($ast));
+    }
+}

--- a/tests/unit/ViewModel/GraphqlViewModelTest.php
+++ b/tests/unit/ViewModel/GraphqlViewModelTest.php
@@ -23,4 +23,17 @@ class GraphqlViewModelTest extends TestCase
         $sut = new GraphqlViewModel($dummyEventDispatcher);
         $this->assertSame($query, trim($sut->query('test', $query)));
     }
+
+    public function testDispatchesEvent()
+    {
+        $queryIdentifier = 'test';
+        $mockEventDispatcher = $this->createMock(EventManager::class);
+        $sut = new GraphqlViewModel($mockEventDispatcher);
+
+        $mockEventDispatcher->expects($this->once())
+                            ->method('dispatch')
+                            ->with('hyva_graphql_query_before_render_' . $queryIdentifier,  $this->anything());
+
+        $sut->query($queryIdentifier, '{dummy}');
+    }
 }

--- a/tests/unit/ViewModel/GraphqlViewModelTest.php
+++ b/tests/unit/ViewModel/GraphqlViewModelTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/**
+ * Hyvä Themes - https://hyva.io
+ * Copyright © Hyvä Themes. All rights reserved.
+ * See LICENSE.md for license details
+ */
+
+namespace Hyva\GraphqlViewModel\ViewModel;
+
+use Magento\Framework\Event\ManagerInterface as EventManager;
+use PHPUnit\Framework\TestCase;
+
+class GraphqlViewModelTest extends TestCase
+{
+    public function testReturnsQueryString(): void
+    {
+        $query = '{
+  __type(name: "Customer") {
+    name
+  }
+}';
+        $dummyEventDispatcher = $this->createMock(EventManager::class);
+        $sut = new GraphqlViewModel($dummyEventDispatcher);
+        $this->assertSame($query, trim($sut->query('test', $query)));
+    }
+}


### PR DESCRIPTION
The issue came up in the discussion of a PR to the Yireo_WebP compat module.

There currently is no way to request additional fields in GraphQL queries, that are usually embedded in .phtml templates.

Accessing additional related data is a common task in modules.

My first idea for a solution would be a service as a view model, that takes a GraphQL query string, parses it into a PHP array, dispatches an event and also provides a public method to plug into, and then returns the query as a string again.
In a template, instead of:

```php
$query = "
products(filter: {} pageSize: 20) {
  items {
    {$type}_products {
        sku
        id
        small_image {
          url
        }
    }
  }
}";
```

the code would look something like:

```php
$query = $gqlViewModel->query("product_list_query", "
products(filter: {} pageSize: 20) {
  items {
    {$type}_products {
        sku
        id
        small_image {
          url
        }
    }
  }
}");
```

The goal here would be to introduce as little complexity as possible from a developer perspective and keep backward compatibility.


A query customization is done with an event observer:

```php
$query = $event->getData('gql_container')->getData('query');

$gqlEditor = new GraphqlQueryEditor();

// add a single field to a result object
$query = $gqlEditor->setFieldIn($query, ['products', 'items', 'small_image'], 'url_webp');

// add multiple fields to a result object
$query = $gqlEditor->setFieldIn($query, ['products', 'items', 'image'], 'url label url_webp');

// add a query argument
$query = $gqlEditor->setArgumentIn($query, ['products', 'filter', 'name'], 'match', 'Tank');
$query = $gqlEditor->setArgumentIn($query, ['products'], 'pageSize', 2);

$event->getData('gql_container')->setData('query', $query);
```